### PR TITLE
Adding NodeFilter to TrieRT

### DIFF
--- a/kad/triert/config.go
+++ b/kad/triert/config.go
@@ -6,14 +6,20 @@ import (
 
 // Config holds configuration options for a TrieRT.
 type Config[K kad.Key[K], N kad.NodeID[K]] struct {
-	// KeyFilter defines the filter that is applied before a key is added to the table.
+	// KeyFilter defines the filter that is applied before a key is added to the
+	// table. KeyFilter is applied before NodeFilter.
 	// If nil, no filter is applied.
 	KeyFilter KeyFilterFunc[K, N]
+	// NodeFilter defines the filter that is applied before a node is added to
+	// the table. NodeFilter is applied after KeyFilter.
+	// If nil, no filter is applied.
+	NodeFilter NodeFilter[K, N]
 }
 
 // DefaultConfig returns a default configuration for a TrieRT.
 func DefaultConfig[K kad.Key[K], N kad.NodeID[K]]() *Config[K, N] {
 	return &Config[K, N]{
-		KeyFilter: nil,
+		KeyFilter:  nil,
+		NodeFilter: nil,
 	}
 }

--- a/kad/triert/filter.go
+++ b/kad/triert/filter.go
@@ -11,3 +11,16 @@ func BucketLimit20[K kad.Key[K], N kad.NodeID[K]](rt *TrieRT[K, N], kk K) bool {
 	cpl := rt.Cpl(kk)
 	return rt.CplSize(cpl) < 20
 }
+
+// NodeFilter provides a stateful way to filter nodes before they are added to
+// the table. The filter is applied after the key filter.
+type NodeFilter[K kad.Key[K], N kad.NodeID[K]] interface {
+	// TryAdd is called when a node is added to the table. Return true to allow
+	// the node to be added. Return false to prevent the node from being added
+	// to the table. When updating its state, the NodeFilter considers that the
+	// node has been added to the table if TryAdd returns true.
+	TryAdd(rt *TrieRT[K, N], node N) bool
+	// Remove is called when a node is removed from the table, allowing the
+	// filter to update its state.
+	Remove(node N)
+}


### PR DESCRIPTION
Adding `NodeFilter` to `TrieRT` allowing to prevent specific nodes from being included in the routing table, and allowing to implement a diversity filter for the routing table.

https://github.com/libp2p/go-libp2p-kad-dht/issues/909